### PR TITLE
Fix memory leaks in auth pages

### DIFF
--- a/untitled folder/flutter_application_1/lib/auth/login_page.dart
+++ b/untitled folder/flutter_application_1/lib/auth/login_page.dart
@@ -2,9 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'register_page.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    emailController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
 
   void login(BuildContext context) async {
     try {

--- a/untitled folder/flutter_application_1/lib/auth/register_page.dart
+++ b/untitled folder/flutter_application_1/lib/auth/register_page.dart
@@ -1,9 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-class RegisterPage extends StatelessWidget {
+class RegisterPage extends StatefulWidget {
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    emailController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
 
   void register(BuildContext context) async {
     try {

--- a/untitled folder/flutter_application_1/lib/main.dart
+++ b/untitled folder/flutter_application_1/lib/main.dart
@@ -1,8 +1,6 @@
-import 'package:flutter/material.dart';
 import 'pages/home_page.dart';
 import 'pages/user_page.dart';
 import 'auth/auth_gate.dart';
-
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart'; // gegenereerd door flutterfire configure


### PR DESCRIPTION
## Summary
- fix memory leak by converting login and register pages to StatefulWidgets and disposing controllers
- remove duplicate material import in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae148280832d9dae424ca0592de4