### PR TITLE
Restrict routes per user in Flutter app

### DIFF
--- a/untitled folder/flutter_application_1/lib/pages/new_route_page.dart
+++ b/untitled folder/flutter_application_1/lib/pages/new_route_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:latlong2/latlong.dart';
 
 class NewRoutePage extends StatefulWidget {
@@ -58,6 +59,10 @@ class _NewRoutePageState extends State<NewRoutePage> {
     if (widget.existingRoute != null) {
       await widget.existingRoute!.reference.update(routeData);
     } else {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user != null) {
+        routeData['user_id'] = user.uid;
+      }
       await FirebaseFirestore.instance.collection('routes').add(routeData);
     }
 

--- a/untitled folder/flutter_application_1/lib/pages/routeoverview_page.dart
+++ b/untitled folder/flutter_application_1/lib/pages/routeoverview_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_application_1/pages/new_route_page.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -10,7 +11,12 @@ class RoutesOverviewPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text('Mijn Routes')),
       body: StreamBuilder<QuerySnapshot>(
-        stream: FirebaseFirestore.instance.collection('routes').snapshots(),
+        stream: FirebaseAuth.instance.currentUser == null
+            ? const Stream.empty()
+            : FirebaseFirestore.instance
+                .collection('routes')
+                .where('user_id', isEqualTo: FirebaseAuth.instance.currentUser!.uid)
+                .snapshots(),
         builder: (context, snapshot) {
           print("Routes snapshot state: ${snapshot.connectionState}");
 


### PR DESCRIPTION
## Summary
- add `firebase_auth` import to route overview
- filter route list on logged-in user's uid
- store the `user_id` when creating a route

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc394184832db604ea2ca1d93eb7